### PR TITLE
Upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,91 @@
-*.pyc
-/kruxstatsd.egg-info
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+cover/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+.noseids
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/dev-requirements.pip
+++ b/dev-requirements.pip
@@ -3,7 +3,7 @@
 
 # For unit tests
 coverage==4.2
-# GOTCHA: This is the last version we can build in Jenkins due to the setuptools version limit.
+# GOTCHA: 1.1.2 is the last version of mock we can build in Jenkins due to the setuptools version limit.
 mock==1.1.2
 nose==1.3.7
 fudge==1.1.0

--- a/dev-requirements.pip
+++ b/dev-requirements.pip
@@ -2,9 +2,7 @@
 -r requirements.pip
 
 # For unit tests
-# GOTCHA: Coverage is pegged at the latest version of 3, because of the error it throw when detemining
-# branch coverage.
-coverage==3.7.1
+coverage==4.2
 # GOTCHA: This is the last version we can build in Jenkins due to the setuptools version limit.
 mock==1.1.2
 nose==1.3.7

--- a/dev-requirements.pip
+++ b/dev-requirements.pip
@@ -6,6 +6,7 @@ coverage==4.2
 # GOTCHA: This is the last version we can build in Jenkins due to the setuptools version limit.
 mock==1.1.2
 nose==1.3.7
+fudge==1.1.0
 
 # Transitive libraries
 

--- a/dev-requirements.pip
+++ b/dev-requirements.pip
@@ -1,0 +1,17 @@
+# Include base requirements
+-r requirements.pip
+
+# For unit tests
+# GOTCHA: Coverage is pegged at the latest version of 3, because of the error it throw when detemining
+# branch coverage.
+coverage==3.7.1
+# GOTCHA: This is the last version we can build in Jenkins due to the setuptools version limit.
+mock==1.1.2
+nose==1.3.7
+
+# Transitive libraries
+
+# From mock
+funcsigs==1.0.2
+pbr==1.10.0
+six==1.10.0

--- a/kruxstatsd/cli.py
+++ b/kruxstatsd/cli.py
@@ -8,7 +8,6 @@
 #
 
 import sys
-import random
 import time
 
 #
@@ -68,14 +67,14 @@ class Application(object):
         return parser
 
     def run(self):
-        self.stats.incr('test', random.randint(1, 10))
-        self.stats.incr(stat='kwargs_test', count=random.randint(1, 10))
-        self.stats.gauge('test', random.randint(1, 10))
-        self.stats.gauge(1, random.randint(1, 10))
-        self.stats.gauge(['list', 'test'], random.randint(1, 10))
-        self.stats.gauge(stat=['list', 'kwargs', 1], value=random.randint(1, 10))
+        self.stats.incr('test', 2)
+        self.stats.incr(stat='kwargs_test', count=3)
+        self.stats.gauge('test', 4)
+        self.stats.gauge(1, 5)
+        self.stats.gauge(['list', 'test'], 6)
+        self.stats.gauge(stat=['list', 'kwargs', 1], value=7)
         with self.stats.timer('test'):
-            time.sleep(random.randint(1, 5))
+            time.sleep(1)
 
 
 def main():

--- a/kruxstatsd/cli.py
+++ b/kruxstatsd/cli.py
@@ -69,6 +69,7 @@ class Application(object):
 
     def run(self):
         self.stats.incr('test', random.randint(1, 10))
+        self.stats.incr(stat='kwargs_test', count=random.randint(1, 10))
         self.stats.gauge('test', random.randint(1, 10))
         with self.stats.timer('test'):
             time.sleep(random.randint(1, 5))

--- a/kruxstatsd/cli.py
+++ b/kruxstatsd/cli.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# © 2011-2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+import sys
+import random
+
+#
+# Third party libraries
+#
+
+import statsd
+from argparse import ArgumentParser
+
+#
+# Internal libraries
+#
+
+import kruxstatsd
+
+
+class Application(object):
+    NAME = 'kruxstatsd-test'
+    DEFAULT_HOST = 'localhost'
+    DEFAULT_PORT = 8125
+    DEFAULT_ENVIRONMENT = 'dev'
+
+    def __init__(self, name=NAME, *arg, **kwargs):
+        self.name = name
+
+        self.parser = self.get_parser(description=self.name)
+        self.add_cli_arguments(self.parser)
+        self.args = self.parser.parse_args()
+
+        self.stats = kruxstatsd.StatsClient(
+            prefix=self.name,
+            host=self.args.host,
+            port=self.args.port,
+            env=self.args.environment,
+        )
+
+    def get_parser(self, description):
+        return ArgumentParser(description=description)
+
+    def add_cli_arguments(self, parser):
+        parser.add_argument(
+            '-H', '--host',
+            default=self.DEFAULT_HOST,
+            help='Statsd host to send statistics to. (default: %(default)s)',
+        )
+        parser.add_argument(
+            '-p', '--port',
+            default=self.DEFAULT_PORT,
+            help='Statsd port to send statistics to. (default: %(default)s)',
+        )
+        parser.add_argument(
+            '-e', '--environment',
+            default=self.DEFAULT_ENVIRONMENT,
+            help='Statsd environment. (default: %(default)s)',
+        )
+
+        return parser
+
+    def run(self):
+        self.stats.incr('test', random.randint(1, 10))
+
+
+def main():
+    Application().run()
+
+
+# Run the application stand alone
+if __name__ == '__main__':
+    main()

--- a/kruxstatsd/cli.py
+++ b/kruxstatsd/cli.py
@@ -25,6 +25,15 @@ import kruxstatsd
 
 
 class Application(object):
+    """
+    A CLI application designed for development testing of kruxstatsd.
+    The goal of this class is to provide a quick and dirty client of kruxstatsd to be used during development.
+
+    This does not replace a proper unit test.
+    Also, unlike other CLI applications for krux libraries, this class is not designed to be inherited by other
+    CLI as a quick bootstrap of kruxstatsd. Use krux.cli.Application for that.
+    """
+
     NAME = 'kruxstatsd-test'
     DEFAULT_HOST = 'localhost'
     DEFAULT_PORT = 8125

--- a/kruxstatsd/cli.py
+++ b/kruxstatsd/cli.py
@@ -71,6 +71,9 @@ class Application(object):
         self.stats.incr('test', random.randint(1, 10))
         self.stats.incr(stat='kwargs_test', count=random.randint(1, 10))
         self.stats.gauge('test', random.randint(1, 10))
+        self.stats.gauge(1, random.randint(1, 10))
+        self.stats.gauge(['list', 'test'], random.randint(1, 10))
+        self.stats.gauge(stat=['list', 'kwargs', 1], value=random.randint(1, 10))
         with self.stats.timer('test'):
             time.sleep(random.randint(1, 5))
 

--- a/kruxstatsd/cli.py
+++ b/kruxstatsd/cli.py
@@ -9,6 +9,7 @@
 
 import sys
 import random
+import time
 
 #
 # Third party libraries
@@ -68,6 +69,9 @@ class Application(object):
 
     def run(self):
         self.stats.incr('test', random.randint(1, 10))
+        self.stats.gauge('test', random.randint(1, 10))
+        with self.stats.timer('test'):
+            time.sleep(random.randint(1, 5))
 
 
 def main():

--- a/kruxstatsd/client.py
+++ b/kruxstatsd/client.py
@@ -1,7 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# © 2011-2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
 import socket
 from functools import wraps
 
+#
+# Third party libraries
+#
+
 import statsd
+
+#
+# Internal libraries
+#
 
 
 class StatsClient(object):

--- a/kruxstatsd/client.py
+++ b/kruxstatsd/client.py
@@ -56,8 +56,12 @@ class StatsClient(object):
         if callable(attr):
             @wraps(attr)
             def wrapper(*args, **kwargs):
-                if not args:
+                if len(args) > 0:
+                    return attr(self._format(args[0]), *args[1:], **kwargs)
+                elif kwargs.get('stat', None) is not None:
+                    kwargs['stat'] = self._format(kwargs['stat'])
                     return attr(*args, **kwargs)
-                return attr(self._format(args[0]), *args[1:], **kwargs)
+                else:
+                    return attr(*args, **kwargs)
             return wrapper
         return attr

--- a/kruxstatsd/client.py
+++ b/kruxstatsd/client.py
@@ -44,8 +44,16 @@ class StatsClient(object):
 
     def _format(self, stat):
         """Format a stats string with the environment, prefix and hostname."""
-        return '%s.%s.%s.%s' % (
-            self.env, self.prefix, stat, self.hostname)
+        stat_list = [self.env, self.prefix]
+
+        if isinstance(stat, list):
+            stat_list += [str(s) for s in stat]
+        else:
+            stat_list.append(str(stat))
+
+        stat_list.append(self.hostname)
+
+        return '.'.join(stat_list)
 
     def __getattr__(self, attr):
         """Proxies calls to ``statsd.StatsClient`` methods.

--- a/kruxstatsd/tests.py
+++ b/kruxstatsd/tests.py
@@ -1,13 +1,32 @@
-import kruxstatsd
+# -*- coding: utf-8 -*-
+#
+# © 2011-2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
 import socket
+
+#
+# Third party libraries
+#
+
+import statsd
 import fudge
 from fudge.inspector import arg
 
-import statsd
+#
+# Internal libraries
+#
+
+import kruxstatsd
+
 
 hostname = socket.gethostname().split('.')[0]
-env      = 'prod'
-prefix   = 'js'
+env = 'prod'
+prefix = 'js'
 
 
 def mock_statsd_method(kls, stat, count=1, rate=1):

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,5 +1,5 @@
 # The library this is wrapping
-statsd==2.0.3
+statsd==3.2.1
 
 # For cli.py
 argparse==1.4.0

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,9 @@
 # The library this is wrapping
 statsd==2.0.3
 
+# For cli.py
+argparse==1.4.0
+
 # Transitive libraries
 # This is needed so there are no version conflicts when
 # one downstream library does NOT specify the version it wants,

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,3 +1,7 @@
+# The library this is wrapping
 statsd==2.0.3
-fudge==1.0.3
-nose==1.2.1
+
+# Transitive libraries
+# This is needed so there are no version conflicts when
+# one downstream library does NOT specify the version it wants,
+# and another one does.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+description-file = README.rst
+
+[nosetests]
+cover-branches = 1
+cover-html = 1
+cover-inclusive = 1
+cover-package = kruxstatsd
+verbosity = 2
+with-coverage = 1
+with-id = 1

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,6 @@ setup(
         'coverage==4.2',
         'mock==1.1.2',
         'nose==1.3.7',
+        'fudge==1.1.0',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ import os
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.2.4'
+VERSION = '0.3.0'
 
 # URL to the repository on Github.
-REPO_URL     = 'https://github.com/krux/python-kruxstatsd'
+REPO_URL = 'https://github.com/krux/python-kruxstatsd'
 
 # Github will generate a tarball as long as you tag your releases, so don't
 # forget to tag!
@@ -20,20 +20,20 @@ DOWNLOAD_URL = ''.join((REPO_URL, '/tarball/release/', VERSION))
 
 
 setup(
-    name                 = 'kruxstatsd',
-    version              = VERSION,
-    author               = 'Paul Osman',
-    maintainer           = 'Paul Lathrop',
-    maintainer_email     = 'paul@krux.com',
-    description          = 'Wrapper around pystatsd with automatic namespacing',
-    url                  = REPO_URL,
-    download_url         = DOWNLOAD_URL,
-    license              = 'MIT',
-    packages             = find_packages(),
-    install_requires     = [
+    name='kruxstatsd',
+    version=VERSION,
+    author='Paul Osman',
+    maintainer='Paul Lathrop',
+    maintainer_email='paul@krux.com',
+    description='Wrapper around pystatsd with automatic namespacing',
+    url=REPO_URL,
+    download_url=DOWNLOAD_URL,
+    license='MIT',
+    packages=find_packages(),
+    install_requires=[
         'statsd==2.0.3',
     ],
-    tests_require        = [
+    tests_require=[
         'nose==1.1.2',
         'fudge==1.0.3'
     ]

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
         'statsd==2.0.3',
     ],
     tests_require=[
-        'nose==1.1.2',
-        'fudge==1.0.3'
+        'coverage==4.2',
+        'mock==1.1.2',
+        'nose==1.3.7',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     license='MIT',
     packages=find_packages(),
     install_requires=[
-        'statsd==2.0.3',
+        'statsd==3.2.1',
         'argparse==1.4.0',
     ],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,17 @@ setup(
     packages=find_packages(),
     install_requires=[
         'statsd==2.0.3',
+        'argparse==1.4.0',
     ],
     tests_require=[
         'coverage==4.2',
         'mock==1.1.2',
         'nose==1.3.7',
         'fudge==1.1.0',
-    ]
+    ],
+    entry_points={
+        'console_scripts': [
+            'kruxstatsd-test = kruxstatsd.cli:main',
+        ],
+    }
 )


### PR DESCRIPTION
## What does this PR do?
1. `setup.py` has been linted and is now following PEP8 guideline.
1. `requirements.pip` has been commented and the testing requirements are now separated to `dev-requirements.pip`.
1. `statsd` requirement has been updated.
1. `setup.cfg` has been updated for better unit testing outputs.
1. `.gitignore` has been updated to match that of [`krux-autoscale`](https://github.com/krux/python-krux-autoscale/blob/master/.gitignore). `krux-autoscale`'s is in turn a copy of [GitHub](https://github.com/github/gitignore/blob/master/Python.gitignore)'s with minor changes.
1. `kruxstatsd/tests.py`'s and `kruxstatsd/client.py`'s import statements are commented, and copyright notice is added to two files.
1. `kruxstatsd/cli.py` is added to ease the testing.
1. `StatsClient` is updated so that the whether the methods are called with positional parameters or keyword parameters, the correct formatting is applied.
1. `StatsClient` is updated so that a list can be passed as a `stats` parameter.

## Why is this change being made?
1. This repository has not been updated in couple years. Some maintenance work is nice.
2. I was getting sick of creating a gigantic format string to pass as `stats` parameter. I wanted to update it to pass a list.
3. Being able to handle both positional parameters and keyword parameters is just added bonus from 2.

## Where should the reviewer start?
`kruxstatsd/cli.py` demonstrates all new features. This would be a good place to start.

## How was this tested? How can the reviewer verify your testing?
The change was manually tested on `phan-dev001.krxd.net`. The resulting stats can be seen on [grafana](http://grafana.krxd.net/grafana/dashboard/db/peters-dashboard?panelId=2&fullscreen).