### PR TITLE
Fixing install_requires in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# JetBrain IDE settings
+.idea/

--- a/dev-requirements.pip
+++ b/dev-requirements.pip
@@ -3,12 +3,16 @@
 
 # For unit tests
 coverage==4.2
-# GOTCHA: 1.1.2 is the last version of mock we can build in Jenkins due to the setuptools version limit.
-mock==1.1.2
+# GOTCHA: Make sure this is installed with the latest version of pip. Without it, you will run into following error:
+# `error in setup command: Error parsing /data/jenkins/workspace/python-krux-boto-pull-request/.ci.virtualenv/build/mock/setup.cfg: SyntaxError: '<' operator not allowed in environment markers`
+mock==2.0.0
 nose==1.3.7
 fudge==1.1.0
 
 # Transitive libraries
+# This is needed so there are no version conflicts when
+# one downstream library does NOT specify the version it wants,
+# and another one does.
 
 # From mock
 funcsigs==1.0.2

--- a/setup.py
+++ b/setup.py
@@ -31,14 +31,14 @@ setup(
     license='MIT',
     packages=find_packages(),
     install_requires=[
-        'statsd==3.2.1',
-        'argparse==1.4.0',
+        'statsd',
+        'argparse',
     ],
     tests_require=[
-        'coverage==4.2',
-        'mock==1.1.2',
-        'nose==1.3.7',
-        'fudge==1.1.0',
+        'coverage',
+        'mock',
+        'nose',
+        'fudge',
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.3.0'
+VERSION = '0.3.1'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-kruxstatsd'


### PR DESCRIPTION
## What does this PR do?

This PR removes all version info from `install_requires` attribute in `setup.py`.

## Why is this change being made?

With the version set, it creates conflicts with other repositories when they install a different version of the same dependency.

## How was this tested? How can the reviewer verify your testing?

The change was tested manually in the development environment.
