### PR TITLE
Fix Pipfile & Pipfile.lock for pipenv

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,4 +1,14 @@
 [[source]]
+url = "${KRUX_PIP_PROP_URL}"
+verify_ssl = true
+name = "kruxprop"
+
+[[source]]
+url = "${KRUX_PIP_FOSS_URL}"
+verify_ssl = true
+name = "kruxfoss"
+
+[[source]]
 url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -9,19 +9,19 @@
         },
         "sources": [
             {
-                "name": "pypi",
-                "url": "https://pypi.org/simple",
+                "name": "kruxprop",
+                "url": "${KRUX_PIP_PROP_URL}",
                 "verify_ssl": true
             },
             {
                 "name": "kruxfoss",
                 "url": "${KRUX_PIP_FOSS_URL}",
-                "verify_ssl": false
+                "verify_ssl": true
             },
             {
-                "name": "kruxprop",
-                "url": "${KRUX_PIP_PROP_URL}",
-                "verify_ssl": false
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
             }
         ]
     },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8cee40361c74dedc3a2b05dda96569ce9690c9b0a24b84a1db9ad8c19f487a56"
+            "sha256": "11cb7e230a73f50bbbb61dbdf6a5736f004823a0f802b0ba111997da2d66890c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -12,6 +12,16 @@
                 "name": "pypi",
                 "url": "https://pypi.org/simple",
                 "verify_ssl": true
+            },
+            {
+                "name": "kruxfoss",
+                "url": "${KRUX_PIP_FOSS_URL}",
+                "verify_ssl": false
+            },
+            {
+                "name": "kruxprop",
+                "url": "${KRUX_PIP_PROP_URL}",
+                "verify_ssl": false
             }
         ]
     },

--- a/kruxstatsd/_version.py
+++ b/kruxstatsd/_version.py
@@ -1,2 +1,2 @@
 # Source of truth for version number. Put nothing else here.
-__version__ = '0.3.4'
+__version__ = '0.3.5'


### PR DESCRIPTION
## What does this PR do?
Fixes Pipfile & Pipfile.lock so that they point to Krux’s repos.

**NOTE**: You will need to set the `KRUX_PIP_FOSS_URL ` and `KRUX_PIP_PROP_URL ` environment variables to use pipenv.

## Why is this change being made?
pipenv was failing befause the our repo sources were misconfigure in Pipfile.

## How does this PR do it?
Small edits to Pipfile & Pipfile.lock.

## How was this tested? How can the reviewer verify your testing?
```
pipenv install --deploy --sequential --dev
pipenv run python setup.py citest || pipenv run nosetests
```

## Completion checklist
- [x] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
- [x] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation is up to date and correct.
- [x] Dependencies are correctly listed under `requirements.pip` and
      are up to date without going over a major version.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] The change is either small or have been canaried in the appropriate environment(s).
