### PR TITLE
Let kdata_processing install on Bionic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,14 @@
 # © 2013 Krux Digital, Inc.
 #
 
-from pip.req    import parse_requirements
 from setuptools import setup, find_packages
-
+import subprocess
 import os
+import sys
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.2.2'
+VERSION      = '0.2.2.post1'
 
 # URL to the repository on Github.
 REPO_URL     = 'https://github.com/krux/python-kruxstatsd'
@@ -29,9 +29,10 @@ REQUIREMENTS = os.path.join(BASE_DIR, 'requirements.pip')
 # A requirement file can contain comments (#) and can include some other
 # files (--requirement or -r), so we need to use pip's parser to get the
 # final list of dependencies.
-DEPENDENCIES = [unicode(package.req)
-                for package in parse_requirements(REQUIREMENTS)]
-
+DEPENDENCIES = []
+subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-r', 'requirements.pip'])
+freeze = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
+DEPENDENCIES = freeze.split('\n')
 
 setup(
     name                 = 'kruxstatsd',


### PR DESCRIPTION
## What does this PR do?
This change makes `setup.py` compatible with older & newer versions of pip. The [pip manual strongly recommends this usage pattern over using the pip module directly within your code](https://pip.pypa.io/en/stable/user_guide/#using-pip-from-your-program).

Note that this is a [_post release_](https://www.python.org/dev/peps/pep-0440/#post-releases) for an ancient version.
 
## Why is this change being made?
[W-5913185](https://gus.lightning.force.com/lightning/r/a07B0000006QoC8IAK/view) _[PE-7570] BIONIC UPGRADE – clusters in s_periodic::base role_

[kdata_processing](https://github.com/krux/puppet-manifests/tree/master/krux-modules/kdata_processing) uses [an extremely old version of data-processing](https://github.com/krux/data-processing/tree/release/0.0.26) and of [python-kruxstatsd](https://github.com/krux/python-kruxstatsd/tree/release/0.2.2). The `setup.py` in those versions is incompatible with newer versions of pip, which causes installs to fail.

## How does this PR do it?
Calls the pip command to extract requirements from `requirements.pip`.

## How was this tested? How can the reviewer verify your testing?
Tested on my laptop using `pip==1.4.1` & `pip==19.1`.

## What gif best describes this PR or how it makes you feel?
![trKjqGJ](https://user-images.githubusercontent.com/496931/57171238-53998400-6dc7-11e9-98f1-f36839cd387b.gif)

## Completion checklist
- [x] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
- [x] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation is up to date and correct.
- [x] Dependencies are correctly listed under `Pipfile` and
      are up to date without going over a major version.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] The change is either small or have been canaried in the appropriate environment(s).